### PR TITLE
Copy IMPORT_PREFIX and IMPORT_SUFFIX target properties for unity targets.

### DIFF
--- a/CMake/cotire.cmake
+++ b/CMake/cotire.cmake
@@ -2757,7 +2757,8 @@ function (cotire_setup_unity_build_target _languages _configurations _targetSour
 		LIBRARY_OUTPUT_NAME LIBRARY_OUTPUT_NAME_<CONFIG>
 		OUTPUT_NAME OUTPUT_NAME_<CONFIG>
 		RUNTIME_OUTPUT_NAME RUNTIME_OUTPUT_NAME_<CONFIG>
-		PREFIX <CONFIG>_POSTFIX SUFFIX)
+		PREFIX <CONFIG>_POSTFIX SUFFIX
+		IMPORT_PREFIX IMPORT_SUFFIX)
 	# copy compile stuff
 	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
 		COMPILE_DEFINITIONS COMPILE_DEFINITIONS_<CONFIG>


### PR DESCRIPTION

For unity targets, the PREFIX and SUFFIX target properties were being
copied so that library output file names would make the non-unity
target.  However, this wasn't the case for IMPORT_PREFIX and
IMPORT_SUFFIX which control the import library file name on Windows.  As
a result, the unity target and the original target differed in the
output file name for import libraries.

This fix simply adds IMPORT_PREFIX and IMPORT_SUFFIX to the list of
properties being copied from the original target.