### PR TITLE
Add detection of defined <LANG>_COMPILER_LAUNCHER vars

### DIFF
--- a/CMake/cotire.cmake
+++ b/CMake/cotire.cmake
@@ -1811,7 +1811,8 @@ function (cotire_check_precompiled_header_support _language _target _msgVar)
 	else()
 		set (${_msgVar} "${_unsupportedCompiler}." PARENT_SCOPE)
 	endif()
-	if (CMAKE_${_language}_COMPILER MATCHES "ccache")
+	get_target_property(launcher ${_target} ${_language}_COMPILER_LAUNCHER)
+	if (CMAKE_${_language}_COMPILER MATCHES "ccache" OR launcher MATCHES "ccache")
 		if (NOT "$ENV{CCACHE_SLOPPINESS}" MATCHES "time_macros|pch_defines")
 			set (${_msgVar}
 				"ccache requires the environment variable CCACHE_SLOPPINESS to be set to \"pch_defines,time_macros\"."


### PR DESCRIPTION
Since CMake 3.3 it is possible to use <LANG>_COMPILER_LAUNCHER target
property to define ccache. So we need to check those setting, too.


See:
* https://cmake.org/cmake/help/v3.4/prop_tgt/LANG_COMPILER_LAUNCHER.html
* https://cmake.org/gitweb?p=cmake.git;h=698f75971bee336133d21260db069bb139bd3d76
