### PR TITLE
Include `cotire` in example

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 # cotire example project
 
+include(cotire)
+
 add_executable(example main.cpp example.cpp log.cpp log.h example.h)
 
 # enable warnings


### PR DESCRIPTION
Wasn't able to build without this line. Now builds fine.
