### PR TITLE
Fix automoc interference with unity source generation on WIN32

### DIFF
--- a/CMake/cotire.cmake
+++ b/CMake/cotire.cmake
@@ -3005,7 +3005,7 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 	else()
 		add_library(${_unityTargetName} ${_unityTargetSubType} EXCLUDE_FROM_ALL ${_unityTargetSources})
 	endif()
-	if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
+	if (MSVC)
 		# depend on original target's automoc target, if it exists
 		if (TARGET ${_target}_automoc)
 			add_dependencies(${_unityTargetName} ${_target}_automoc)


### PR DESCRIPTION
This fixes the error:

   The dependency target "foo_automoc" of target "foo_unity" does not exist.

Tested with:

    - CMake 3.8.0-rc1
    - Ninja Generator
    - MSVC 14.0 Compiler
    - CMAKE_AUTOMOC enabled

Fixes #54