### PR TITLE
Add cotire_add_library macro

### DIFF
--- a/CMake/cotire.cmake
+++ b/CMake/cotire.cmake
@@ -4052,3 +4052,17 @@ else()
 	message (STATUS "cotire ${COTIRE_CMAKE_MODULE_VERSION} loaded.")
 
 endif()
+
+
+macro (cotire_add_library name)
+  set (orig_target ${name}_orig)
+  # add regular target with another name
+  add_library (${orig_target} ${ARGN})
+  set_target_properties (${orig_target} PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
+  # set unity target name with the original name
+  set_target_properties (${orig_target} PROPERTIES COTIRE_UNITY_TARGET_NAME ${name})
+  # add unity build target
+  cotire (${orig_target})
+  set_target_properties (${name} PROPERTIES EXCLUDE_FROM_ALL 0 EXCLUDE_FROM_DEFAULT_BUILD 0)
+  set_target_properties (${name} PROPERTIES OUTPUT_NAME ${name})
+endmacro ()


### PR DESCRIPTION
This adds a new macro that adds a cotired library with a desired name.

The use case is when a project has rules depending on a target we want to cotire, after doing cotire(name) we have to modify these rules to depend on name_unity, that's basically #55. Instead, I propose to use cotire_add_library instead of the regular add_library, and that's it!

Internally, it adds the regular target name_orig, then cotires it with the provided name.
Inspired by https://github.com/onqtam/ucm.

For discussion, there's not documentation yet. Maybe it could also be extended for executables.


