### PR TITLE
Add support for MSVC JOM and Ninja builds

### DIFF
--- a/CMake/cotire.cmake
+++ b/CMake/cotire.cmake
@@ -1589,20 +1589,23 @@ function (cotire_add_pch_compilation_flags _language _compilerID _compilerVersio
 		file (TO_NATIVE_PATH "${_prefixFile}" _prefixFileNative)
 		file (TO_NATIVE_PATH "${_pchFile}" _pchFileNative)
 		file (TO_NATIVE_PATH "${_hostFile}" _hostFileNative)
+		string (REGEX REPLACE "\\.[^.]*$" ".obj" _objFileNative "${_hostFileNative}")
 		# cl.exe options used
 		# /Yc creates a precompiled header file
 		# /Fp specifies precompiled header binary file name
 		# /FI forces inclusion of file
 		# /TC treat all files named on the command line as C source files
 		# /TP treat all files named on the command line as C++ source files
-		# /Zs syntax check only
+		# /c stop compilation after creating an object file
+		# /Fo specifies object file name
 		# /Zm precompiled header memory allocation scaling factor
 		set (_sourceFileTypeC "/TC")
 		set (_sourceFileTypeCXX "/TP")
 		if (_flags)
 			# append to list
 			list (APPEND _flags /nologo "${_sourceFileType${_language}}"
-				"/Yc${_prefixFileNative}" "/Fp${_pchFileNative}" "/FI${_prefixFileNative}" /Zs "${_hostFileNative}")
+				"/Yc${_prefixFileNative}" "/Fp${_pchFileNative}" "/FI${_prefixFileNative}" /c "/Fo${_objFileNative}"
+				"${_hostFileNative}")
 			if (COTIRE_PCH_MEMORY_SCALING_FACTOR)
 				list (APPEND _flags "/Zm${COTIRE_PCH_MEMORY_SCALING_FACTOR}")
 			endif()
@@ -2261,7 +2264,7 @@ endfunction()
 
 function (cotire_setup_pch_file_compilation _language _target _targetScript _prefixFile _pchFile _hostFile)
 	set (_sourceFiles ${ARGN})
-	if (CMAKE_${_language}_COMPILER_ID MATCHES "MSVC|Intel")
+	if (CMAKE_${_language}_COMPILER_ID MATCHES "MSVC|Intel" AND NOT "${CMAKE_GENERATOR}" MATCHES "Make|Ninja")
 		# for Visual Studio and Intel, we attach the precompiled header compilation to the host file
 		# the remaining files include the precompiled header, see cotire_setup_pch_file_inclusion
 		if (_sourceFiles)
@@ -2293,9 +2296,16 @@ function (cotire_setup_pch_file_compilation _language _target _targetScript _pre
 			if (COTIRE_DEBUG)
 				message (STATUS "add_custom_command: OUTPUT ${_pchFile} ${_cmds} DEPENDS ${_prefixFile} ${_realCompilerExe} IMPLICIT_DEPENDS ${_language} ${_prefixFile}")
 			endif()
+			set (_outputFiles "")
+			list (APPEND _outputFiles "${_pchFile}")
 			set_property (SOURCE "${_pchFile}" PROPERTY GENERATED TRUE)
+			if (CMAKE_${_language}_COMPILER_ID MATCHES "MSVC")
+				string (REGEX REPLACE "\\.[^.]*$" ".obj" _hostObjFile "${_hostFile}")
+				list (APPEND _outputFiles "${_hostObjFile}")
+				set_property (SOURCE "${_hostObjFile}" PROPERTY GENERATED TRUE)
+			endif()
 			add_custom_command(
-				OUTPUT "${_pchFile}"
+				OUTPUT ${_outputFiles}
 				COMMAND ${_cmds}
 				DEPENDS "${_prefixFile}" "${_realCompilerExe}"
 				IMPLICIT_DEPENDS ${_language} "${_prefixFile}"
@@ -2307,7 +2317,7 @@ function (cotire_setup_pch_file_compilation _language _target _targetScript _pre
 endfunction()
 
 function (cotire_setup_pch_file_inclusion _language _target _wholeTarget _prefixFile _pchFile _hostFile)
-	if (CMAKE_${_language}_COMPILER_ID MATCHES "MSVC|Intel")
+	if (CMAKE_${_language}_COMPILER_ID MATCHES "MSVC|Intel" AND NOT "${CMAKE_GENERATOR}" MATCHES "Make|Ninja")
 		# for Visual Studio and Intel, we include the precompiled header in all but the host file
 		# the host file does the precompiled header compilation, see cotire_setup_pch_file_compilation
 		set (_sourceFiles ${ARGN})
@@ -2454,9 +2464,9 @@ function (cotire_setup_target_pch_usage _languages _target _wholeTarget)
 		# if this is a single-language target without any excluded files
 		if (_wholeTarget)
 			set (_language "${_languages}")
-			# for Visual Studio and Intel, precompiled header inclusion is always done on the source file level
+			# for Intel, precompiled header inclusion is always done on the source file level
 			# see cotire_setup_pch_file_inclusion
-			if (NOT CMAKE_${_language}_COMPILER_ID MATCHES "MSVC|Intel")
+			if (NOT CMAKE_${_language}_COMPILER_ID MATCHES "Intel")
 				get_property(_prefixFile TARGET ${_target} PROPERTY COTIRE_${_language}_PREFIX_HEADER)
 				if (_prefixFile)
 					get_property(_pchFile TARGET ${_target} PROPERTY COTIRE_${_language}_PRECOMPILED_HEADER)
@@ -2883,6 +2893,16 @@ function (cotire_process_target_language _language _configurations _target _whol
 		if (_targetUsePCH)
 			cotire_make_pch_file_path(${_language} ${_target} _pchFile)
 			if (_pchFile)
+				if (CMAKE_${_language}_COMPILER_ID MATCHES "MSVC" AND "${CMAKE_GENERATOR}" MATCHES "Make|Ninja")
+					# use stub file to link in precompiled header
+					string (REGEX REPLACE "\\.[^.]*$" "_stub.cxx" _stubFile "${_prefixFile}")
+					file (WRITE "${_stubFile}" "#include \"${_prefixFile}\"")
+					list (INSERT _sourceFiles 0 "${_stubFile}")
+					string (REGEX REPLACE "\\.[^.]*$" ".obj" _stubObjFile "${_stubFile}")
+					set_property (SOURCE "${_stubObjFile}" PROPERTY GENERATED TRUE)
+					target_sources (${_target} PRIVATE "${_stubObjFile}")
+					set_property(TARGET ${_target} PROPERTY COTIRE_${_language}_STUB_OBJECT "${_stubObjFile}")
+				endif()
 				# first file in _sourceFiles is passed as the host file
 				cotire_setup_pch_file_compilation(
 					${_language} ${_target} "${_targetConfigScript}" "${_prefixFile}" "${_pchFile}" ${_sourceFiles})
@@ -2970,6 +2990,11 @@ function (cotire_collect_unity_target_sources _target _languages _unityTargetSou
 			cotire_filter_language_source_files(${_language} ${_target} _sourceFiles _excludedSources _cotiredSources ${_targetSourceFiles})
 			if (_sourceFiles OR _cotiredSources)
 				list (REMOVE_ITEM _unityTargetSources ${_sourceFiles} ${_cotiredSources})
+			endif()
+			if (CMAKE_${_language}_COMPILER_ID MATCHES "MSVC" AND "${CMAKE_GENERATOR}" MATCHES "Make|Ninja")
+				# remove pch stub object file
+				get_property(_stubObjFile TARGET ${_target} PROPERTY COTIRE_${_language}_STUB_OBJECT)
+				list (REMOVE_ITEM _unityTargetSources "${_stubObjFile}")
 			endif()
 			# add unity source files instead
 			list (APPEND _unityTargetSources ${_unityFiles})


### PR DESCRIPTION
Stub file used due to [​Linker Tools Error LNK2011](https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-error-lnk2011). Successfully tested with the NMake Makefiles JOM, Ninja and NMake Makefiles generators on Windows, and Ninja and Unix Makefiles generators on Linux.