### PR TITLE
Fix moc files not using PCH when cotired. Added the possibility to specify the path to stdafx.cpp to cotire instead of passing it as first argument to add_library and add_executable.

### DIFF
--- a/CMake/cotire.cmake
+++ b/CMake/cotire.cmake
@@ -254,6 +254,18 @@ function (cotire_filter_language_source_files _language _target _sourceFilesVar 
 			message (STATUS "Cotired ${_target} ${_language} sources: ${_cotiredSourceFiles}")
 		endif()
 	endif()
+	get_target_property(_targetAutoMoc ${_target} AUTOMOC)
+	get_target_property(_targetAutoUic ${_target} AUTOUIC)
+	get_target_property(_targetAutoRcc ${_target} AUTORCC)
+	if (_targetAutoMoc OR _targetAutoUic OR _targetAutoRcc)
+		# if the original target sources are subject to CMake's automatic Qt processing,
+		# also include implicitly generated <targetname>_automoc.cpp file
+		if (CMAKE_VERSION VERSION_LESS "3.8.0")
+			list (APPEND _sourceFiles "${CMAKE_CURRENT_BINARY_DIR}/${_target}_automoc.cpp")
+		else()
+			list (APPEND _sourceFiles "${CMAKE_CURRENT_BINARY_DIR}/${_target}_autogen/mocs_compilation.cpp")
+		endif()
+	endif()
 	set (${_sourceFilesVar} ${_sourceFiles} PARENT_SCOPE)
 	set (${_excludedSourceFilesVar} ${_excludedSourceFiles} PARENT_SCOPE)
 	set (${_cotiredSourceFilesVar} ${_cotiredSourceFiles} PARENT_SCOPE)

--- a/CMake/cotire.cmake
+++ b/CMake/cotire.cmake
@@ -2829,6 +2829,18 @@ function (cotire_compute_unity_max_number_of_includes _target _maxIncludesVar)
 	set (${_maxIncludesVar} ${_maxIncludes} PARENT_SCOPE)
 endfunction()
 
+function (cotire_get_source_list_without_host_file _hostFile _sourceFiles _sourceFilesWithoutHostFile)
+	get_filename_component(realPathToHostFile ${_hostFile} REALPATH)
+	set(outputList "")
+	foreach(sourceFile ${_sourceFiles})
+		get_filename_component(realPathToFile ${sourceFile} REALPATH)
+		if (NOT ${realPathToHostFile} STREQUAL ${realPathToFile})
+			list(APPEND outputList ${sourceFile})
+		endif()
+	endforeach()
+	set(${_sourceFilesWithoutHostFile} ${outputList} PARENT_SCOPE)
+endfunction()
+
 function (cotire_process_target_language _language _configurations _target _wholeTarget _cmdsVar)
 	set (${_cmdsVar} "" PARENT_SCOPE)
 	get_target_property(_targetSourceFiles ${_target} SOURCES)
@@ -2883,11 +2895,20 @@ function (cotire_process_target_language _language _configurations _target _whol
 		if (_targetUsePCH)
 			cotire_make_pch_file_path(${_language} ${_target} _pchFile)
 			if (_pchFile)
-				# first file in _sourceFiles is passed as the host file
+				# check for user provided prefix header files
+				get_property(_hostHeaderFile TARGET ${_target} PROPERTY COTIRE_${_language}_PREFIX_HEADER_HOST_INIT)
+				set(_hostFile "")
+				if (_hostHeaderFile)
+					set(_hostFile ${_hostHeaderFile})
+				else()
+					# first file in _sourceFiles is passed as the host file
+					list(GET _sourceFiles 0 _hostFile)
+				endif()
+				cotire_get_source_list_without_host_file(${_hostFile} "${_sourceFiles}" sourceFilesWithoutHostFile)
 				cotire_setup_pch_file_compilation(
-					${_language} ${_target} "${_targetConfigScript}" "${_prefixFile}" "${_pchFile}" ${_sourceFiles})
+					${_language} ${_target} "${_targetConfigScript}" "${_prefixFile}" "${_pchFile}" "${_hostFile}" ${sourceFilesWithoutHostFile})
 				cotire_setup_pch_file_inclusion(
-					${_language} ${_target} ${_wholeTarget} "${_prefixFile}" "${_pchFile}" ${_sourceFiles})
+					${_language} ${_target} ${_wholeTarget} "${_prefixFile}" "${_pchFile}" "${_hostFile}" ${sourceFilesWithoutHostFile})
 			endif()
 		elseif (_prefixHeaderFiles)
 			# user provided prefix header must be included unconditionally
@@ -3944,6 +3965,16 @@ else()
 			"If set, cotire will add the given header file(s) to the generated prefix header file."
 			"If not set, cotire will generate a prefix header by tracking the header files included by the unity source file."
 			"The property can be set to a user provided prefix header file (e.g., stdafx.h)."
+			"Defaults to empty."
+	)
+
+	define_property(
+		TARGET PROPERTY "COTIRE_<LANG>_PREFIX_HEADER_HOST_INIT"
+		BRIEF_DOCS "User provided host file to be used instead of the first one in the sources list."
+		FULL_DOCS
+			"If set, cotire will the given source file as a host file for precompiled header creation."
+			"If not set, cotire will use the first file passed as parameter to add_library or add_executable as host file."
+			"The property can be set to a user provided PCH host file (e.g., stdafx.cpp)."
 			"Defaults to empty."
 	)
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -340,8 +340,15 @@ file. The path is interpreted relative to the target source directory:
     cotire(example)
 
 If the prefix header `stdafx.h` needs an accompanying source file (e.g., `stdafx.cpp`) in order
-to be precompiled properly, that source file needs to be the first one on the list of source
-files in the target's `add_executable` or `add_library` call.
+to be precompiled properly, you should set the target property `COTIRE_CXX_PREFIX_HEADER_HOST_INIT`
+to this file:
+
+    set_target_properties(example PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT "stdafx.h")
+    set_target_properties(example PROPERTIES COTIRE_CXX_PREFIX_HEADER_HOST_INIT "stdafx.cpp")
+    cotire(example)
+
+Otherwise, that source file needs to be the first one on the list of source files in the target's
+`add_executable` or `add_library` call.
 
 The property `COTIRE_CXX_PREFIX_HEADER_INIT` can also be set to a list of header files which will
 then make up the contents of the generated prefix header.


### PR DESCRIPTION
This merge request fixes two issues that were showstoppers for me. Please integrate them, or not, as you see fit. Everything included here is just a suggestion.

If you want me to refine these commits to be more consistent with your style, I'll be happy to. In this case just tell me the issues you see.