### PR TITLE
Fix generator expression for binary targets in compile definitions

### DIFF
--- a/CMake/cotire.cmake
+++ b/CMake/cotire.cmake
@@ -2355,12 +2355,22 @@ function (cotire_generate_target_script _language _configurations _target _targe
 		CMAKE_${_language}_SOURCE_FILE_EXTENSIONS)
 		if (DEFINED ${_var})
 			string (REPLACE "\"" "\\\"" _value "${${_var}}")
-			set (_contents "${_contents}set (${_var} \"${_value}\")\n")
-			if (NOT _contentsHasGeneratorExpressions)
-				if ("${_value}" MATCHES "\\$<.*>")
+
+			if ("${_value}" MATCHES "\\$<.*>")
+				# We have to evaluate generator expressions
+				if (NOT _contentsHasGeneratorExpressions)
 					set (_contentsHasGeneratorExpressions TRUE)
 				endif()
+
+				# Expand various generator expressions which can only be evaluated on binary targets manually
+				foreach(_currentReplacedGeneratorExpression "C_COMPILER_ID" "CXX_COMPILER_ID")
+					set(_currentReplacement ${CMAKE_${_currentReplacedGeneratorExpression}})
+
+					string (REGEX REPLACE "\\$<${_currentReplacedGeneratorExpression}:([a-zA-Z0-9]*)>" "$<STREQUAL:\\\\\"${_currentReplacement}\\\\\",\\\\\"\\1\\\\\">" _value "${_value}")
+				endforeach(_currentReplacedGeneratorExpression)
 			endif()
+
+			set (_contents "${_contents}set (${_var} \"${_value}\")\n")
 		endif()
 	endforeach()
 	# generate target script file


### PR DESCRIPTION
* Affected generator expressions are replaced through the global
  variable value and a corresponding STREQUAL generator expression.
* Closes sakra/cotire#135

**This needs some proper testing!**